### PR TITLE
Fixing inverted parameters in TokenExchangeSkillHandler.cs

### DIFF
--- a/templates/csharp/VA/VA/TokenExchange/TokenExchangeSkillHandler.cs
+++ b/templates/csharp/VA/VA/TokenExchange/TokenExchangeSkillHandler.cs
@@ -114,8 +114,8 @@ namespace $safeprojectname$.TokenExchange
                                 // AAD token exchange
                                 var result = await _tokenExchangeProvider.ExchangeTokenAsync(
                                     context,
-                                    activity.Recipient?.Id,
                                     _tokenExchangeConfig.ConnectionName,
+                                    activity.Recipient?.Id,
                                     new TokenExchangeRequest() { Uri = oauthCard.TokenExchangeResource.Uri }).ConfigureAwait(false);
 
                                 if (!string.IsNullOrEmpty(result.Token))


### PR DESCRIPTION
Actual values for connectionName and userId parameters were inverted while invoking tokenExchangeProvider.ExchangeTokenAsync() method.

Fixes microsoft/botframework-solutions#3654